### PR TITLE
URL seems to have changed

### DIFF
--- a/app/config/config.ts
+++ b/app/config/config.ts
@@ -34,7 +34,7 @@ export default {
         },
         BusinessMessages: {
             // Errors
-            BadDOTFormatFromSlack: 'Incorrect format, see the <www.graphviz.org/Documentation/dotguide.pdf|DOT guide> ' +
+            BadDOTFormatFromSlack: 'Incorrect format, see the <https://www.graphviz.org/pdf/dotguide.pdf|DOT guide> ' +
             'or examples below:\n>>>`digraph{beaver->platypus duck->platypus}`\n`graph{ying--yang}`',
             BadDOTLengthFromSlack: 'DOT string is great than 500 characters, please by kind to my little server',
 


### PR DESCRIPTION
Update to a URL that works

Prepended "https://" because the interface is considering `www.graphviz.org/Documentation/dotguide.pdf` to be a local ref based from the URL of the slack site, not a URL on its own.  Apparently `http://app.slack.com/www.graphviz.org/Documentation/dotguide.pdf` doesn't exist :(